### PR TITLE
Build both MacOs, and linux

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,7 +29,8 @@ jobs:
       - run: ./gradlew build
       - uses: actions/upload-artifact@v3
         with:
-          path: | 
-            build/reports/tests
+          path: |
+            postgres-native-sqldelight-dialect/build/reports/tests
+            postgres-native-sqldelight-driver/build/reports/tests
             testing/build/reports/tests
         if: failure()

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ 'macos-latest', 'ubuntu-latest' ]
+        os: [ 'ubuntu-latest' ]
     steps:
       - uses: actions/checkout@v3
       - uses: Homebrew/actions/setup-homebrew@master
@@ -26,7 +26,7 @@ jobs:
       - uses: ikalnytskyi/action-setup-postgres@v3
         with:
           password: password
-      - run: ./gradlew :postgres-native-sqldelight-driver:test --tests '*wrongCredentials'
+      - run: ./gradlew :postgres-native-sqldelight-driver:linuxX64Test --tests '*wrongCredentials'
       - run: ./gradlew build
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: ikalnytskyi/action-setup-postgres@v3
         with:
           password: password
+      - run: ./gradlew :postgres-native-sqldelight-driver:test --tests '*wrongCredentials'
       - run: ./gradlew build
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,20 +8,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_PASSWORD: password
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ 'macos-latest', 'ubuntu-latest' ]
     steps:
       - uses: actions/checkout@v3
       - uses: Homebrew/actions/setup-homebrew@master
@@ -33,6 +23,9 @@ jobs:
           distribution: 'adopt'
           java-version: 11
       - run: ./gradlew assemble
+      - uses: ikalnytskyi/action-setup-postgres@v3
+        with:
+          password: password
       - run: ./gradlew build
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Fixes #3 
by using [Setup PostgreSQL for Linux/macOS/Windows](https://github.com/marketplace/actions/setup-postgresql-for-linux-macos-windows) for running PostgreSQL service on both `ubuntu-latest` and `macos-latest`.